### PR TITLE
Fix most test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm: 2.4.5
 services:
   - docker
 
+env:
+  OPENVIDU_VERIFY_PEER: false
+
 before_install:
   - gem install bundler -v 1.17.3
   - docker pull openvidu/openvidu-server-kms

--- a/lib/open_vidu/version.rb
+++ b/lib/open_vidu/version.rb
@@ -1,3 +1,3 @@
 module OpenVidu
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/openvidu-ruby-client.gemspec
+++ b/openvidu-ruby-client.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'test-unit', '~> 3.3', '>= 3.3.4'
+  spec.add_development_dependency 'openssl', '>= 2.1.2' # Fix for Travis CI
 
   spec.add_development_dependency 'dotenv', '~> 2.7', '>= 2.7.5'
   spec.add_runtime_dependency 'httparty', '>= 0.13'


### PR DESCRIPTION
Fixes 'read server hello A' error by using a newer version of the openssl ruby library. Also disables peer verification since the OV docker image uses a self signed cert.