### PR TITLE
Add support for managing multiple OpenVidu instances within the same process

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,18 @@ docker run -p 4443:4443 -d --rm -e openvidu.secret=MY_SECRET -e openvidu.recordi
 
 Set the following environment variables in your Ruby application:
 
-```bash
-OPENVIDU_URL = 'https://localhost:4443'
-OPENVIDU_USERNAME = 'OPENVIDUAPP'
-OPENVIDU_PASSWORD = 'MY_SECRET'
-OPENVIDU_VERIFY_PEER=false
-```
-
 To start a OpenVidu session:
 
 ```ruby
-OpenVidu::Session.create(
+server = 'https://127.0.0.1:4443?token=MY_SECRET'
+
+OpenVidu::Session.new(server,
   customSessionId: 'your-custom-session-id',
   defaultOutputMode: 'INDIVIDUAL',
-  recordingMode: 'ALWAYS')
+  recordingMode: 'ALWAYS').create
 
 # Create a token to publish video
-token = OpenVidu::Token.create(session: 'your-custom-session-id,
+token = OpenVidu::Token.new(server, session: 'your-custom-session-id,
   role: "PUBLISHER",
   data: {
     "full_name": "John Smith"  # Custom data can be supplied here

--- a/lib/open_vidu.rb
+++ b/lib/open_vidu.rb
@@ -1,6 +1,7 @@
 require "open_vidu/version"
+require "open_vidu/base"
 
 module OpenVidu
   class Error < StandardError; end
-  # Your code goes here...
+
 end

--- a/lib/open_vidu/base.rb
+++ b/lib/open_vidu/base.rb
@@ -1,4 +1,5 @@
 require 'open_vidu/command'
+require 'open_vidu/server'
 
 module OpenVidu
   # Base
@@ -7,11 +8,14 @@ module OpenVidu
     GENERATED_PARAMS = %w[].freeze
     ALL_PARAMS = (ASSIGNABLE_PARAMS + GENERATED_PARAMS).freeze
 
+    attr_reader :server
+
     def self.content_key
       'content'
     end
 
-    def initialize(params = {})
+    def initialize(uri, params = {})
+      @server = Server.new(uri).freeze
       self.class::ALL_PARAMS.each do |param|
         instance_variable_set("@#{param}", params[param.to_sym])
         self.class.send(:attr_accessor, param.to_sym)

--- a/lib/open_vidu/command.rb
+++ b/lib/open_vidu/command.rb
@@ -5,7 +5,7 @@ require 'open_vidu/exceptions'
 module OpenVidu
   # Command
   class Command
-    attr_reader :object, :method, :endpoint, :params, :requestor, :responder
+    attr_reader :object, :method, :endpoint, :params, :requestor, :responder, :server
 
     def initialize(object, method, endpoint, params = {}, options: {})
       @object = object
@@ -13,14 +13,15 @@ module OpenVidu
       @endpoint = endpoint
       @params = params
 
-      @requestor = options[:requestor] || OpenVidu::Requestor.new(method, endpoint, params)
+      @server = options.fetch(:server)
+      @requestor = options[:requestor] || OpenVidu::Requestor.new(server, method, endpoint, params)
       @responder = options[:responder] || OpenVidu::Responder.new
     end
 
     def execute
       response = requestor.execute
       raise OpenVidu::ResponseError.new(response) unless valid?(response)
-      responder.execute(object, response.parsed_response)
+      responder.execute(server, object, response.parsed_response)
     end
 
     private

--- a/lib/open_vidu/config.rb
+++ b/lib/open_vidu/config.rb
@@ -12,8 +12,8 @@ module OpenVidu
     ].freeze
     ALL_PARAMS = (ASSIGNABLE_PARAMS + GENERATED_PARAMS).freeze
 
-    def self.config
-      OpenVidu::Command.new(:config, :get, 'config').execute
+    def config
+      OpenVidu::Command.new(:config, :get, 'config', { options: {server: server } }).execute
     end
   end
 end

--- a/lib/open_vidu/recording.rb
+++ b/lib/open_vidu/recording.rb
@@ -14,19 +14,19 @@ module OpenVidu
       'items'
     end
 
-    def self.all
+    def all
       OpenVidu::Command.new(
-        :recording, :get, 'api/recordings'
+        :recording,
+        :get,
+        'api/recordings',
+        { options: { server: server } }
       ).execute
     end
 
-    def self.create(params)
-      new(params).create
-    end
-
-    def self.find(id)
+    def find(id)
       OpenVidu::Command.new(
-        :recording, :get, "api/recordings/#{id}"
+        :recording, :get, "api/recordings/#{id}",
+        { options: { server: server } }
       ).execute
     end
 
@@ -34,7 +34,8 @@ module OpenVidu
       OpenVidu::Command.new(
         :recording,
         :post,
-        "api/recordings/stop/#{id}"
+        "api/recordings/stop/#{id}",
+        { options: { server: server } }
       ).execute
     end
 
@@ -42,13 +43,18 @@ module OpenVidu
       OpenVidu::Command.new(
         :recording,
         :delete,
-        "api/recordings/#{id}"
+        "api/recordings/#{id}",
+        { options: { server: server } }
       ).execute
     end
 
     def create
       OpenVidu::Command.new(
-        :recording, :post, 'api/recordings/start', create_params
+        :recording,
+        :post,
+        'api/recordings/start',
+        create_params,
+        { options: { server: server } }
       ).execute
     end
 

--- a/lib/open_vidu/requestor.rb
+++ b/lib/open_vidu/requestor.rb
@@ -4,13 +4,10 @@ require 'json'
 module OpenVidu
   # Requestor
   class Requestor
-    attr_reader :method, :endpoint, :params
+    attr_reader :server, :method, :endpoint, :params
 
-    BASE_URL = ENV['OPENVIDU_URL']
-    TOKEN = "#{ENV['OPENVIDU_USERNAME']}:#{ENV['OPENVIDU_PASSWORD']}".freeze
-    VERIFY_PEER = ENV['OPENVIDU_VERIFY_PEER']
-
-    def initialize(method, endpoint, params = {})
+    def initialize(server, method, endpoint, params = {})
+      @server = server
       @method = method
       @endpoint = endpoint
       @params = params
@@ -23,16 +20,16 @@ module OpenVidu
     private
 
     def url
-      "#{BASE_URL}/#{endpoint}"
+      "#{server.scheme}://#{server.host}:#{server.port || 4443}/#{endpoint}"
     end
 
     def options
       {
         headers: {
-          'Authorization' => "Basic #{Base64.strict_encode64(TOKEN)}",
+          'Authorization' => "Basic #{Base64.strict_encode64(server.token)}",
           'Content-Type' => 'application/json'
         },
-        verify: VERIFY_PEER != 'false',
+        verify: server.verify_peer?,
         body: params.to_json
       }
     end

--- a/lib/open_vidu/responder.rb
+++ b/lib/open_vidu/responder.rb
@@ -3,16 +3,16 @@ module OpenVidu
   class Responder
     attr_reader :object, :response
 
-    def execute(object, response)
+    def execute(server, object, response)
       @object = object
       @response = response
       klass = Object.const_get(klass_name)
 
       return true if record_destroyed?
-      return klass.new(mapped_params(response)) if complete_record?
-      return klass.find(response['id']) if record_lookup?
+      return klass.new(server, mapped_params(response)) if complete_record?
+      return klass.new(server).find(response['id']) if record_lookup?
 
-      response[content_key].map { |hash| klass.new(mapped_params(hash)) }
+      response[content_key].map { |hash| klass.new(server, mapped_params(hash)) }
     end
 
     private

--- a/lib/open_vidu/server.rb
+++ b/lib/open_vidu/server.rb
@@ -1,0 +1,39 @@
+require 'addressable'
+require 'forwardable'
+
+module OpenVidu
+  # Endpoint configuration
+  class Server
+    extend Forwardable
+
+    InvalidURI = Class.new(StandardError)
+
+    def_delegators :@uri, :host, :port, :scheme, :query_values, :to_s
+
+    # `uri` should take the form of scheme://some-openvidu-host-or-ip:port?token=<your-secret-here>
+    # e.g. https://1.2.3.4?token=abcdefghijklmnop
+    def initialize(uri)
+      @uri = Addressable::URI.parse(uri.to_s)
+      raise InvalidURI if @uri.empty?
+    end
+
+    def token
+      "OPENVIDUAPP:#{query_values.fetch('token')}"
+    end
+
+    def host_and_port
+      "#{host}:#{port}"
+    end
+
+    def verify_peer?
+      return false if query_values['verify_peer'].to_s.downcase == 'false'
+
+      true
+    end
+
+    def ==(other)
+      other.to_s == self.to_s
+    end
+  end
+end
+

--- a/lib/open_vidu/session.rb
+++ b/lib/open_vidu/session.rb
@@ -8,26 +8,22 @@ module OpenVidu
     GENERATED_PARAMS = %w[sessionId createdAt connections recording].freeze
     ALL_PARAMS = (ASSIGNABLE_PARAMS + GENERATED_PARAMS).freeze
 
-    def self.all
+    def all
       OpenVidu::Command.new(
-        :session, :get, 'api/sessions'
+        :session, :get, 'api/sessions', { options: { server: server } }
       ).execute
     end
 
-    def self.create(params)
-      new(params).create
-    end
-
-    def self.find(id)
+    def find(id)
       OpenVidu::Command.new(
-        :session, :get, "api/sessions/#{id}"
+        :session, :get, "api/sessions/#{id}", { options: { server: server } }
       ).execute
     end
 
-    def self.exists?(id)
+    def exists?(id)
       begin
         OpenVidu::Command.new(
-            :session, :get, "api/sessions/#{id}"
+          :session, :get, "api/sessions/#{id}", { options: { server: server } }
         ).execute
         true
       rescue OpenVidu::ResponseError => e
@@ -38,13 +34,13 @@ module OpenVidu
 
     def create
       OpenVidu::Command.new(
-        :session, :post, 'api/sessions', create_params
+        :session, :post, 'api/sessions', create_params, { options: { server: server } }
       ).execute
     end
 
     def delete
       OpenVidu::Command.new(
-        :session, :delete, "api/sessions/#{customSessionId}"
+        :session, :delete, "api/sessions/#{customSessionId}", { options: { server: server } }
       ).execute
     end
   end

--- a/lib/open_vidu/token.rb
+++ b/lib/open_vidu/token.rb
@@ -5,13 +5,9 @@ module OpenVidu
     GENERATED_PARAMS = %w[id token].freeze
     ALL_PARAMS = (ASSIGNABLE_PARAMS + GENERATED_PARAMS).freeze
 
-    def self.create(params)
-      new(params).create
-    end
-
     def create
       OpenVidu::Command.new(
-        :token, :post, 'api/tokens', create_params
+        :token, :post, 'api/tokens', create_params, options: { server: server }
       ).execute
     end
   end

--- a/openvidu-ruby-client.gemspec
+++ b/openvidu-ruby-client.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.7'
   spec.add_development_dependency 'simplecov', '~> 0.17'
 
+  spec.add_runtime_dependency 'addressable', '>= 2.5.0'
   spec.add_development_dependency 'dotenv', '~> 2.7', '>= 2.7.5'
   spec.add_runtime_dependency 'httparty', '>= 0.13'
 end

--- a/openvidu-ruby-client.gemspec
+++ b/openvidu-ruby-client.gemspec
@@ -41,6 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.17'
 
   spec.add_runtime_dependency 'addressable', '>= 2.5.0'
-  spec.add_development_dependency 'dotenv', '~> 2.7', '>= 2.7.5'
   spec.add_runtime_dependency 'httparty', '>= 0.13'
 end

--- a/test/integration/open_vidu/config_test.rb
+++ b/test/integration/open_vidu/config_test.rb
@@ -12,7 +12,7 @@ module OpenVidu
     end
     
     def test_config
-      response = OpenVidu::Config.config
+      response = OpenVidu::Config.new('https://127.0.0.1?token=MY_SECRET&verify_peer=false').config
 
       refute response.nil?
       assert defined?(response.version)

--- a/test/integration/open_vidu/recording_test.rb
+++ b/test/integration/open_vidu/recording_test.rb
@@ -12,7 +12,7 @@ module OpenVidu
     end
 
     def test_all
-      response = OpenVidu::Recording.all
+      response = OpenVidu::Recording.new(server).all
 
       refute response.nil?
       assert response.is_a?(Array)
@@ -39,6 +39,10 @@ module OpenVidu
         recordingLayout: '',
         customLayout: ''
       }.merge(params)
+    end
+
+    def server
+      Addressable::URI.parse('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
     end
   end
 end

--- a/test/integration/open_vidu/session_test.rb
+++ b/test/integration/open_vidu/session_test.rb
@@ -14,8 +14,8 @@ module OpenVidu
     def test_all
       id = SecureRandom.hex(5)
       params = create_params(customSessionId: id)
-      OpenVidu::Session.create(params)
-      response = OpenVidu::Session.all
+      OpenVidu::Session.new(server, params).create
+      response = OpenVidu::Session.new(server).all
 
       refute response.nil?
       assert response.is_a?(Array)
@@ -25,43 +25,43 @@ module OpenVidu
     def test_create
       id = SecureRandom.hex(5)
       params = create_params(customSessionId: id)
-      response = OpenVidu::Session.create(params)
+      response = OpenVidu::Session.new(server, params).create
 
       refute response.nil?
       refute response&.sessionId&.nil?
       assert response.sessionId.eql?(id)
 
-      OpenVidu::Session.find(id).delete
+      OpenVidu::Session.new(server).find(id).delete
     end
 
     def test_instance_create
       id = SecureRandom.hex(5)
       params = create_params(customSessionId: id)
-      response = OpenVidu::Session.new(params).create
+      response = OpenVidu::Session.new(server, params).create
 
       refute response.nil?
       refute response&.sessionId&.nil?
       assert response.sessionId.eql?(id)
 
-      OpenVidu::Session.find(id).delete
+      OpenVidu::Session.new(server).find(id).delete
     end
 
     def test_find
       id = SecureRandom.hex(5)
-      OpenVidu::Session.new(create_params(customSessionId: id)).create
-      response = OpenVidu::Session.find(id)
+      OpenVidu::Session.new(server, create_params(customSessionId: id)).create
+      response = OpenVidu::Session.new(server).find(id)
 
       refute response.nil?
       refute response&.sessionId&.nil?
       assert response.sessionId.eql?(id)
 
-      OpenVidu::Session.find(id).delete
+      OpenVidu::Session.new(server).find(id).delete
     end
 
     def test_delete
       id = SecureRandom.hex(5)
-      OpenVidu::Session.new(create_params(customSessionId: id)).create
-      response = OpenVidu::Session.find(id).delete
+      OpenVidu::Session.new(server, create_params(customSessionId: id)).create
+      response = OpenVidu::Session.new(server).find(id).delete
 
       assert response.eql?(true)
     end
@@ -76,6 +76,10 @@ module OpenVidu
         defaultOutputMode: 'COMPOSED',
         defaultRecordingLayout: 'BEST_FIT'
       }.merge(params)
+    end
+
+    def server
+      Addressable::URI.parse('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
     end
   end
 end

--- a/test/integration/open_vidu/token_test.rb
+++ b/test/integration/open_vidu/token_test.rb
@@ -6,17 +6,17 @@ module OpenVidu
     def setup
       WebMock.disable!
       @id = SecureRandom.hex(5)
-      OpenVidu::Session.create(customSessionId: @id)
+      OpenVidu::Session.new(server, customSessionId: @id).create
     end
 
     def teardown
-      OpenVidu::Session.find(@id).delete
+      OpenVidu::Session.new(server).find(@id).delete
       WebMock.enable!
     end
 
     def test_create
       params = create_params(session: @id)
-      response = OpenVidu::Token.create(params)
+      response = OpenVidu::Token.new(server, params).create
 
       refute response.nil?
       assert response.session == @id
@@ -26,7 +26,7 @@ module OpenVidu
 
     def test_instance_create
       params = create_params(session: @id)
-      response = OpenVidu::Token.new(params).create
+      response = OpenVidu::Token.new(server, params).create
 
       refute response.nil?
       assert response.session == @id
@@ -43,6 +43,10 @@ module OpenVidu
         data: 'metadata',
         kurentoOptions: nil
       }.merge(params)
+    end
+
+    def server
+      Addressable::URI.parse('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
     end
   end
 end

--- a/test/open_vidu/command_test.rb
+++ b/test/open_vidu/command_test.rb
@@ -3,25 +3,32 @@ require 'test_helper'
 class TestCommand < Minitest::Test
   def test_execute
     responder = Minitest::Mock.new
-    responder.expect(:execute, nil, [:session, nil])
+    responder.expect(:execute, nil, [server, :session, nil])
 
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/sessions").to_return(body: "", status: 200)
+    stub_request(:get, "https://#{server.host_and_port}/api/sessions").to_return(body: "", status: 200)
     OpenVidu::Command.new(:session, :get, "api/sessions", options: {
-        responder: responder
+        responder: responder,
+        server: server
     }).execute
 
-    assert_requested(:get, "#{ENV['OPENVIDU_URL']}/api/sessions", times: 1)
+    assert_requested(:get, "https://#{server.host_and_port}/api/sessions", times: 1)
     responder.verify
   end
 
   def test_execute_raises_on_failure
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/sessions").
+    stub_request(:get, "https://#{server.host_and_port}/api/sessions").
       to_return(status:404)
 
     assert_raises(OpenVidu::ResponseError) {
-      OpenVidu::Command.new(:session, :get, "api/sessions").execute
+      OpenVidu::Command.new(:session, :get, "api/sessions", { options: { server: server } }).execute
     }
 
-    assert_requested(:get, "#{ENV['OPENVIDU_URL']}/api/sessions", times: 1)
+    assert_requested(:get, "https://#{server.host_and_port}/api/sessions", times: 1)
+  end
+
+  private
+
+  def server
+    OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
   end
 end

--- a/test/open_vidu/recording_test.rb
+++ b/test/open_vidu/recording_test.rb
@@ -6,34 +6,33 @@ class TestRecording < Minitest::Test
   end
 
   def test_get_all
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/recordings")
-    OpenVidu::Recording.all
-    assert_requested(:get, "#{ENV['OPENVIDU_URL']}/api/recordings", times: 1)
+    stub_request(:get, "https://#{server.host_and_port}/api/recordings")
+    OpenVidu::Recording.new(server).all
+    assert_requested(:get, "https://#{server.host_and_port}/api/recordings", times: 1)
   end
 
   def test_create
-    stub_request(:post, "#{ENV['OPENVIDU_URL']}/api/recordings/start")
-    OpenVidu::Recording.create(create_params)
-    OpenVidu::Recording.new(create_params).create
-    assert_requested(:post, "#{ENV['OPENVIDU_URL']}/api/recordings/start", times: 2, body: create_params)
+    stub_request(:post, "https://#{server.host_and_port}/api/recordings/start")
+    OpenVidu::Recording.new(server, create_params).create
+    assert_requested(:post, "https://#{server.host_and_port}/api/recordings/start", times: 1, body: create_params)
   end
 
   def test_find
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/recordings/test_id")
-    OpenVidu::Recording.find("test_id")
-    assert_requested(:get, "#{ENV['OPENVIDU_URL']}/api/recordings/test_id")
+    stub_request(:get, "https://#{server.host_and_port}/api/recordings/test_id")
+    OpenVidu::Recording.new(server).find("test_id")
+    assert_requested(:get, "https://#{server.host_and_port}/api/recordings/test_id")
   end
 
   def test_stop
-    stub_request(:post, "#{ENV['OPENVIDU_URL']}/api/recordings/stop/ID")
-    OpenVidu::Recording.new(create_params(id: "ID")).stop
-    assert_requested(:post, "#{ENV['OPENVIDU_URL']}/api/recordings/stop/ID")
+    stub_request(:post, "https://#{server.host_and_port}/api/recordings/stop/ID")
+    OpenVidu::Recording.new(server, create_params(id: "ID")).stop
+    assert_requested(:post, "https://#{server.host_and_port}/api/recordings/stop/ID")
   end
 
   def test_delete
-    stub_request(:delete, "#{ENV['OPENVIDU_URL']}/api/recordings/ID")
-    OpenVidu::Recording.new(create_params(id: "ID")).delete
-    assert_requested(:delete, "#{ENV['OPENVIDU_URL']}/api/recordings/ID")
+    stub_request(:delete, "https://#{server.host_and_port}/api/recordings/ID")
+    OpenVidu::Recording.new(server, create_params(id: "ID")).delete
+    assert_requested(:delete, "https://#{server.host_and_port}/api/recordings/ID")
   end
 
   def create_params(params = {})
@@ -47,5 +46,9 @@ class TestRecording < Minitest::Test
         recordingLayout: '',
         customLayout: '',
     }.merge(params)
+  end
+
+  def server
+    OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
   end
 end

--- a/test/open_vidu/requestor_test.rb
+++ b/test/open_vidu/requestor_test.rb
@@ -2,11 +2,17 @@ require 'test_helper'
 
 class TestRequestor < Minitest::Test
   def test_execute
-    stub_request(:get, "https://localhost:4443/test")
-    r = OpenVidu::Requestor.new(:get, "test", {
+    stub_request(:get, "https://127.0.0.1:4443/test").with(body: { 'test_param' => 'A test' }.to_json)
+    r = OpenVidu::Requestor.new(server, :get, "test", {
         'test_param' => 'A test'
     })
     r.execute
-    assert_requested(:get, "https://localhost:4443/test", times:1)
+    assert_requested(:get, "https://127.0.0.1:4443/test", times:1)
+  end
+
+  private
+
+  def server
+    OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
   end
 end

--- a/test/open_vidu/responder_test.rb
+++ b/test/open_vidu/responder_test.rb
@@ -1,28 +1,29 @@
 require 'test_helper'
 
 class FakeSession < Object
-  attr_reader :params, :from_find
+  attr_reader :params, :from_find, :server
 
-  def initialize(params={}, from_find=false)
+  def initialize(server, params={}, from_find=false)
+    @server = server
     @params = params
     @from_find = from_find
   end
 
-  def self.find(id)
-    new({}, true)
+  def find(id)
+    self.class.new(server, {}, true)
   end
 end
 
 class TestResponder < Minitest::Test
   def test_record_destroyed
     r = OpenVidu::Responder.new
-    response = r.execute(:session, nil)
+    response = r.execute(server, :session, nil)
     assert_equal(true, response)
   end
 
   def test_get_complete_record
     r = OpenVidu::Responder.new
-    response = r.execute(:fake_session, {
+    response = r.execute(server, :fake_session, {
         'sessionId' => 'test_id'
     })
 
@@ -31,11 +32,15 @@ class TestResponder < Minitest::Test
 
   def test_record_lookup
     r = OpenVidu::Responder.new
-    response = r.execute(:fake_session, {
+    response = r.execute(server, :fake_session, {
       'id' => 'test',
       'createdAt' => Time.new.to_s
     })
 
     assert_equal(true, response.from_find)
+  end
+
+  def server
+    OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
   end
 end

--- a/test/open_vidu/session_test.rb
+++ b/test/open_vidu/session_test.rb
@@ -3,38 +3,37 @@ require 'test_helper'
 class TestSession < Minitest::Test
   def test_find
     id = 'test_id'
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/sessions/#{id}")
-    OpenVidu::Session.find(id)
+    stub_request(:get, "https://#{server.host_and_port}/api/sessions/#{id}")
+    OpenVidu::Session.new(server).find(id)
 
-    assert_requested(:get, "#{ENV['OPENVIDU_URL']}/api/sessions/#{id}", times: 1)
+    assert_requested(:get, "https://#{server.host_and_port}/api/sessions/#{id}", times: 1)
   end
 
   def test_find_raises_on_404
     id = 'test_id'
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/sessions/#{id}").to_return(status: 404)
+    stub_request(:get, "https://#{server.host_and_port}/api/sessions/#{id}").to_return(status: 404)
     assert_raises(OpenVidu::ResponseError) {
-      OpenVidu::Session.find(id)
+      OpenVidu::Session.new(server).find(id)
     }
 
-    assert_requested(:get, "#{ENV['OPENVIDU_URL']}/api/sessions/#{id}", times: 1)
+    assert_requested(:get, "https://#{server.host_and_port}/api/sessions/#{id}", times: 1)
   end
 
   def test_exists
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/sessions/test_id")
-    assert_equal(true, OpenVidu::Session.exists?("test_id"))
+    stub_request(:get, "https://#{server.host_and_port}/api/sessions/test_id")
+    assert_equal(true, OpenVidu::Session.new(server).exists?("test_id"))
   end
 
   # exists? shoudln't raise on an ResponseError as long as the code is 404
   def test_exists_ok_on_404
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/sessions/test_id").to_return(status: 404)
-    assert_equal(false, OpenVidu::Session.exists?("test_id"))
+    stub_request(:get, "https://#{server.host_and_port}/api/sessions/test_id").to_return(status: 404)
+    assert_equal(false, OpenVidu::Session.new(server).exists?("test_id"))
   end
 
   def test_create
-    stub_request(:post, "#{ENV['OPENVIDU_URL']}/api/sessions")
-    OpenVidu::Session.new(create_params).create
-    OpenVidu::Session.create(create_params)
-    assert_requested(:post, "#{ENV['OPENVIDU_URL']}/api/sessions", times: 2, body: {
+    stub_request(:post, "https://#{server.host_and_port}/api/sessions")
+    OpenVidu::Session.new(server, create_params).create
+    assert_requested(:post, "https://#{server.host_and_port}/api/sessions", times: 1, body: {
         "mediaMode":"ROUTED",
         "recordingMode":"MANUAL",
         "customSessionId":"ID",
@@ -47,15 +46,15 @@ class TestSession < Minitest::Test
   end
 
   def test_delete
-    stub_request(:delete, "#{ENV['OPENVIDU_URL']}/api/sessions/ID")
-    s = OpenVidu::Session.new(create_params).delete
-    assert_requested(:delete, "#{ENV['OPENVIDU_URL']}/api/sessions/ID")
+    stub_request(:delete, "https://#{server.host_and_port}/api/sessions/ID")
+    s = OpenVidu::Session.new(server, create_params).delete
+    assert_requested(:delete, "https://#{server.host_and_port}/api/sessions/ID")
   end
 
   def test_get_all
-    stub_request(:get, "#{ENV['OPENVIDU_URL']}/api/sessions")
-    OpenVidu::Session.all
-    assert_requested(:get, "#{ENV['OPENVIDU_URL']}/api/sessions", times: 1)
+    stub_request(:get, "https://#{server.host_and_port}/api/sessions")
+    OpenVidu::Session.new(server).all
+    assert_requested(:get, "https://#{server.host_and_port}/api/sessions", times: 1)
   end
 
   def create_params(params = {})
@@ -66,5 +65,9 @@ class TestSession < Minitest::Test
         defaultOutputMode: 'COMPOSED',
         defaultRecordingLayout: 'BEST_FIT'
     }.merge(params)
+  end
+
+  def server
+    OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
   end
 end

--- a/test/open_vidu/token_test.rb
+++ b/test/open_vidu/token_test.rb
@@ -6,17 +6,17 @@ class TestToken < Minitest::Test
   end
 
   def test_class_method_create_calls
-    stub_request(:post, "#{ENV['OPENVIDU_URL']}/api/tokens")
+    stub_request(:post, "https://#{server.host_and_port}/api/tokens")
     params = create_params(session: @id)
-    OpenVidu::Token.create(params)
-    assert_requested(:post, "#{ENV['OPENVIDU_URL']}/api/tokens", times:1)
+    OpenVidu::Token.new(server, params).create
+    assert_requested(:post, "https://#{server.host_and_port}/api/tokens", times:1)
   end
 
   def test_instance_create_calls
-    stub_request(:post, "#{ENV['OPENVIDU_URL']}/api/tokens")
+    stub_request(:post, "https://#{server.host_and_port}/api/tokens")
     params = create_params(session: @id)
-    OpenVidu::Token.new(params).create
-    assert_requested(:post, "#{ENV['OPENVIDU_URL']}/api/tokens", times:1)
+    OpenVidu::Token.new(server, params).create
+    assert_requested(:post, "https://#{server.host_and_port}/api/tokens", times:1)
   end
 
   def create_params(params = {})
@@ -26,5 +26,9 @@ class TestToken < Minitest::Test
         data: 'metadata',
         kurentoOptions: nil
     }.merge(params)
+  end
+
+  def server
+    OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,6 @@ SimpleCov.start do
   add_filter "/test/"
 end
 
-require 'dotenv/load'
 require 'open_vidu'
 require 'open_vidu/base'
 require 'open_vidu/command'


### PR DESCRIPTION
In the library's current state, it's not possible for the gem to manage more than one OpenVidu backend. This is because the server configuration is ENV based and geared around a single backend.

To support multiple backends, I removed a few class methods (`find`, `create`) and instead require the use of instance methods for all API calls. This ensures that each call will use a scoped server URI instead of a global one.

New usage looks like:
```ruby
uri = 'https://my-openvidu.wherever.com?token=1234'
session = OpenVidu::Session.new(uri).create
```

It is possible to keep the class methods I removed, but they will require an additional `server`-like parameter. I am not sure it's really useful to support both class and instance variants of a given API call.