### PR TITLE
Support custom timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Set the following environment variables in your Ruby application:
 To start a OpenVidu session:
 
 ```ruby
-server = 'https://127.0.0.1:4443?token=MY_SECRET'
+server = 'https://127.0.0.1:4443?token=MY_SECRET&timeout=5'
 
 OpenVidu::Session.new(server,
   customSessionId: 'your-custom-session-id',

--- a/lib/open_vidu/requestor.rb
+++ b/lib/open_vidu/requestor.rb
@@ -30,6 +30,7 @@ module OpenVidu
           'Content-Type' => 'application/json'
         },
         verify: server.verify_peer?,
+        timeout: server.timeout,
         body: params.to_json
       }
     end

--- a/lib/open_vidu/server.rb
+++ b/lib/open_vidu/server.rb
@@ -8,6 +8,8 @@ module OpenVidu
 
     InvalidURI = Class.new(StandardError)
 
+    DEFAULT_TIMEOUT = 10 # seconds
+
     def_delegators :@uri, :host, :port, :scheme, :query_values, :to_s
 
     # `uri` should take the form of scheme://some-openvidu-host-or-ip:port?token=<your-secret-here>
@@ -29,6 +31,14 @@ module OpenVidu
       return false if query_values['verify_peer'].to_s.downcase == 'false'
 
       true
+    end
+
+    def timeout
+      if query_values['timeout'].to_i > 0
+        query_values['timeout'].to_i
+      else
+        DEFAULT_TIMEOUT
+      end
     end
 
     def ==(other)

--- a/test/open_vidu/server_test.rb
+++ b/test/open_vidu/server_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class TestOpenViduServer < Minitest::Test
+  def test_timeout
+    server = OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false&timeout=42')
+    assert_equal 42, server.timeout
+  end
+
+  def test_default_timeout
+    server = OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
+    assert_equal 10, server.timeout
+  end
+
+  private
+
+  def server
+    OpenVidu::Server.new('https://127.0.0.1:4443?token=MY_SECRET&verify_peer=false')
+  end
+end


### PR DESCRIPTION
Clients can hang forever waiting on a response from Openvidu if it's in a bad state.